### PR TITLE
Add mock objects

### DIFF
--- a/mocks/Event.go
+++ b/mocks/Event.go
@@ -1,0 +1,7 @@
+package mocks
+
+import "github.com/stretchr/testify/mock"
+
+type Event struct {
+	mock.Mock
+}

--- a/mocks/Router.go
+++ b/mocks/Router.go
@@ -1,0 +1,49 @@
+package mocks
+
+import "github.com/eliquious/xrouter"
+import "github.com/stretchr/testify/mock"
+
+import "net/http"
+
+type Router struct {
+	mock.Mock
+}
+
+// StaticRoot provides a mock function with given fields: fs
+func (_m *Router) StaticRoot(fs http.Handler) {
+	_m.Called(fs)
+}
+
+// StaticFiles provides a mock function with given fields: path, fs
+func (_m *Router) StaticFiles(path string, fs http.Handler) {
+	_m.Called(path, fs)
+}
+
+// NotFound provides a mock function with given fields: _a0
+func (_m *Router) NotFound(_a0 http.Handler) {
+	_m.Called(_a0)
+}
+
+// MethodNotAllowed provides a mock function with given fields: _a0
+func (_m *Router) MethodNotAllowed(_a0 http.Handler) {
+	_m.Called(_a0)
+}
+
+// Handler provides a mock function with given fields:
+func (_m *Router) Handler() http.Handler {
+	ret := _m.Called()
+
+	var r0 http.Handler
+	if rf, ok := ret.Get(0).(func() http.Handler); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(http.Handler)
+	}
+
+	return r0
+}
+
+// EventHandler provides a mock function with given fields: _a0
+func (_m *Router) EventHandler(_a0 func(xrouter.Event)) {
+	_m.Called(_a0)
+}

--- a/mocks/RouterGroup.go
+++ b/mocks/RouterGroup.go
@@ -1,0 +1,78 @@
+package mocks
+
+import "github.com/eliquious/xrouter"
+import "github.com/stretchr/testify/mock"
+
+import "github.com/rs/xhandler"
+
+type RouterGroup struct {
+	mock.Mock
+}
+
+// Use provides a mock function with given fields: f
+func (_m *RouterGroup) Use(f func(xhandler.HandlerC) xhandler.HandlerC) {
+	_m.Called(f)
+}
+
+// Group provides a mock function with given fields: path
+func (_m *RouterGroup) Group(path string) xrouter.RouterGroup {
+	ret := _m.Called(path)
+
+	var r0 xrouter.RouterGroup
+	if rf, ok := ret.Get(0).(func(string) xrouter.RouterGroup); ok {
+		r0 = rf(path)
+	} else {
+		r0 = ret.Get(0).(xrouter.RouterGroup)
+	}
+
+	return r0
+}
+
+// Path provides a mock function with given fields:
+func (_m *RouterGroup) Path() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// GET provides a mock function with given fields: path, handler
+func (_m *RouterGroup) GET(path string, handler xhandler.HandlerFuncC) {
+	_m.Called(path, handler)
+}
+
+// POST provides a mock function with given fields: path, handler
+func (_m *RouterGroup) POST(path string, handler xhandler.HandlerFuncC) {
+	_m.Called(path, handler)
+}
+
+// PUT provides a mock function with given fields: path, handler
+func (_m *RouterGroup) PUT(path string, handler xhandler.HandlerFuncC) {
+	_m.Called(path, handler)
+}
+
+// OPTIONS provides a mock function with given fields: path, handler
+func (_m *RouterGroup) OPTIONS(path string, handler xhandler.HandlerFuncC) {
+	_m.Called(path, handler)
+}
+
+// HEAD provides a mock function with given fields: path, handler
+func (_m *RouterGroup) HEAD(path string, handler xhandler.HandlerFuncC) {
+	_m.Called(path, handler)
+}
+
+// PATCH provides a mock function with given fields: path, handler
+func (_m *RouterGroup) PATCH(path string, handler xhandler.HandlerFuncC) {
+	_m.Called(path, handler)
+}
+
+// DELETE provides a mock function with given fields: path, handler
+func (_m *RouterGroup) DELETE(path string, handler xhandler.HandlerFuncC) {
+	_m.Called(path, handler)
+}


### PR DESCRIPTION
This commit adds mock objects for each interface. The structs were generated by `github.com/vektra/mockery`.
