### PR TITLE
Set the middleware chain after adding a middleware

### DIFF
--- a/group.go
+++ b/group.go
@@ -27,7 +27,7 @@ type routerGroup struct {
 
 // Use adds middleware to the router.
 func (r *routerGroup) Use(f func(next http.Handler) http.Handler) {
-	r.chain.Append(f)
+	r.chain = r.chain.Append(f)
 }
 
 // GET adds a GET handler at the given path.

--- a/router.go
+++ b/router.go
@@ -87,7 +87,7 @@ type router struct {
 
 // Use adds middleware to the router.
 func (r *router) Use(f func(next http.Handler) http.Handler) {
-	r.group.chain.Append(f)
+	r.group.Use(f)
 }
 
 // NotFound adds a handler for unknown routes.


### PR DESCRIPTION
Fix a bug which does not add a middleware to the middleware chain.